### PR TITLE
[6주차 미션] 구현 완료했습니다. 리뷰 부탁드립니다.

### DIFF
--- a/src/main/java/codesquad/QnaApplication.java
+++ b/src/main/java/codesquad/QnaApplication.java
@@ -2,7 +2,9 @@ package codesquad;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class QnaApplication {
     public static void main(String[] args) {

--- a/src/main/java/codesquad/domain/BaseTimeEntity.java
+++ b/src/main/java/codesquad/domain/BaseTimeEntity.java
@@ -1,0 +1,20 @@
+package codesquad.domain;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+}

--- a/src/main/java/codesquad/domain/Result.java
+++ b/src/main/java/codesquad/domain/Result.java
@@ -1,0 +1,28 @@
+package codesquad.domain;
+
+public class Result<T> {
+
+    private T data;
+    private String errorMessage;
+
+    private Result(T data, String errorMessage) {
+        this.data = data;
+        this.errorMessage = errorMessage;
+    }
+
+    public static <T> Result<T> ok(T data) {
+        return new Result<>(data, null);
+    }
+
+    public static <T> Result<T> fail(String errorMessage) {
+        return new Result<>(null, errorMessage);
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/codesquad/domain/answer/Answer.java
+++ b/src/main/java/codesquad/domain/answer/Answer.java
@@ -1,12 +1,13 @@
 package codesquad.domain.answer;
 
+import codesquad.domain.BaseTimeEntity;
 import codesquad.domain.question.Question;
 import codesquad.domain.user.User;
 
 import javax.persistence.*;
 
 @Entity
-public class Answer {
+public class Answer extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/codesquad/domain/answer/Answer.java
+++ b/src/main/java/codesquad/domain/answer/Answer.java
@@ -15,14 +15,15 @@ public class Answer {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
     private User writer;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"))
     private Question question;
 
     @Column(columnDefinition = "TEXT", length = 300, nullable = false)
     private String contents;
 
-    private Boolean isDeleted = false;
+    @Column(columnDefinition = "boolean default false")
+    private boolean isDeleted = false;
 
     public Long getId() {
         return id;
@@ -56,7 +57,7 @@ public class Answer {
         this.contents = contents;
     }
 
-    public Boolean getDeleted() {
+    public boolean getDeleted() {
         return isDeleted;
     }
 

--- a/src/main/java/codesquad/domain/answer/Answer.java
+++ b/src/main/java/codesquad/domain/answer/Answer.java
@@ -24,7 +24,17 @@ public class Answer extends BaseTimeEntity {
     private String contents;
 
     @Column(columnDefinition = "boolean default false")
-    private boolean isDeleted = false;
+    private boolean deleted = false;
+
+    public Answer() {
+
+    }
+
+    public Answer(User writer, Question question, String contents) {
+        this.writer = writer;
+        this.question = question;
+        this.contents = contents;
+    }
 
     public Long getId() {
         return id;
@@ -58,8 +68,8 @@ public class Answer extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public boolean getDeleted() {
-        return isDeleted;
+    public boolean isDeleted() {
+        return deleted;
     }
 
     public boolean isSameWriter(User user) {
@@ -67,6 +77,6 @@ public class Answer extends BaseTimeEntity {
     }
 
     public void delete() {
-        isDeleted = true;
+        deleted = true;
     }
 }

--- a/src/main/java/codesquad/domain/answer/AnswerRepository.java
+++ b/src/main/java/codesquad/domain/answer/AnswerRepository.java
@@ -1,6 +1,12 @@
 package codesquad.domain.answer;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @EntityGraph(attributePaths = {"question"})
+    Optional<Answer> findQuestionFetchJoinById(Long id);
 }

--- a/src/main/java/codesquad/domain/question/Question.java
+++ b/src/main/java/codesquad/domain/question/Question.java
@@ -1,5 +1,6 @@
 package codesquad.domain.question;
 
+import codesquad.domain.BaseTimeEntity;
 import codesquad.domain.answer.Answer;
 import codesquad.domain.user.User;
 
@@ -7,7 +8,7 @@ import javax.persistence.*;
 import java.util.List;
 
 @Entity
-public class Question {
+public class Question extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long index;

--- a/src/main/java/codesquad/domain/question/Question.java
+++ b/src/main/java/codesquad/domain/question/Question.java
@@ -3,6 +3,7 @@ package codesquad.domain.question;
 import codesquad.domain.BaseTimeEntity;
 import codesquad.domain.answer.Answer;
 import codesquad.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import java.util.List;
@@ -24,12 +25,13 @@ public class Question extends BaseTimeEntity {
     private String contents;
 
     @OneToMany(mappedBy = "question")
+    @JsonIgnore
     private List<Answer> answers;
 
     private Integer countOfAnswer = 0;
 
     @Column(columnDefinition = "boolean default false")
-    private boolean isDeleted = false;
+    private boolean deleted = false;
 
     public Long getIndex() {
         return index;
@@ -101,7 +103,11 @@ public class Question extends BaseTimeEntity {
     }
 
     public void delete() {
-        isDeleted = true;
+        deleted = true;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
     }
 
     public boolean canDelete() {

--- a/src/main/java/codesquad/domain/question/Question.java
+++ b/src/main/java/codesquad/domain/question/Question.java
@@ -27,7 +27,8 @@ public class Question {
 
     private Integer countOfAnswer = 0;
 
-    private Boolean isDeleted = false;
+    @Column(columnDefinition = "boolean default false")
+    private boolean isDeleted = false;
 
     public Long getIndex() {
         return index;

--- a/src/main/java/codesquad/domain/question/Question.java
+++ b/src/main/java/codesquad/domain/question/Question.java
@@ -24,7 +24,7 @@ public class Question extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String contents;
 
-    @OneToMany(mappedBy = "question")
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<Answer> answers;
 
@@ -111,7 +111,10 @@ public class Question extends BaseTimeEntity {
     }
 
     public boolean canDelete() {
-        if (countOfAnswer.equals(0)) {
+        boolean isAnswerStatusAllTrue = answers.stream()
+                           .allMatch(answer -> answer.isDeleted() == true);
+
+        if (countOfAnswer.equals(0) || isAnswerStatusAllTrue) {
             return true;
         }
         return false;

--- a/src/main/java/codesquad/domain/question/Question.java
+++ b/src/main/java/codesquad/domain/question/Question.java
@@ -24,7 +24,7 @@ public class Question extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String contents;
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "question")
     @JsonIgnore
     private List<Answer> answers;
 

--- a/src/main/java/codesquad/domain/user/User.java
+++ b/src/main/java/codesquad/domain/user/User.java
@@ -1,9 +1,11 @@
 package codesquad.domain.user;
 
+import codesquad.domain.BaseTimeEntity;
+
 import javax.persistence.*;
 
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -38,12 +38,12 @@ public class ApiAnswerController {
     }
 
     @DeleteMapping("/{id}")
-    public Long delete(@PathVariable Long index, @PathVariable Long id, HttpSession httpSession) {
+    public Answer delete(@PathVariable Long index, @PathVariable Long id, HttpSession httpSession) {
         if(!HttpSessionUtil.isLoginUser(httpSession)) {
-            return null;
+            throw new IllegalStateException("세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
 
-        Answer savedAnswer = answerRepository.findById(id).orElseThrow(() -> new NoSuchElementException("답변이 존재하지 않습니다."));
+        Answer savedAnswer = answerRepository.findQuestionFetchJoinById(id).orElseThrow(() -> new NoSuchElementException("답변이 존재하지 않습니다."));
         User sessionedUser = HttpSessionUtil.getUserFrom(httpSession);
 
         if (!savedAnswer.isSameWriter(sessionedUser)) {
@@ -58,6 +58,7 @@ public class ApiAnswerController {
         savedQuestion.deleteAnswer();
 
         questionRepository.save(savedQuestion);
-        return id;
+
+        return savedAnswer;
     }
 }

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -36,4 +36,28 @@ public class ApiAnswerController {
 
         return answerRepository.save(answer);
     }
+
+    @DeleteMapping("/{id}")
+    public Long delete(@PathVariable Long index, @PathVariable Long id, HttpSession httpSession) {
+        if(!HttpSessionUtil.isLoginUser(httpSession)) {
+            return null;
+        }
+
+        Answer savedAnswer = answerRepository.findById(id).orElseThrow(() -> new NoSuchElementException("답변이 존재하지 않습니다."));
+        User sessionedUser = HttpSessionUtil.getUserFrom(httpSession);
+
+        if (!savedAnswer.isSameWriter(sessionedUser)) {
+            throw new IllegalStateException("다른 사람의 게시글을 삭제할 수 없습니다.");
+        }
+
+        savedAnswer.delete();
+
+        answerRepository.save(savedAnswer);
+
+        Question savedQuestion = questionRepository.findById(index).orElseThrow(() -> new NoSuchElementException("게시글이 존재하지 않습니다."));
+        savedQuestion.deleteAnswer();
+
+        questionRepository.save(savedQuestion);
+        return id;
+    }
 }

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -1,0 +1,39 @@
+package codesquad.web;
+
+import codesquad.domain.answer.Answer;
+import codesquad.domain.answer.AnswerRepository;
+import codesquad.domain.question.Question;
+import codesquad.domain.question.QuestionRepository;
+import codesquad.domain.user.User;
+import codesquad.util.HttpSessionUtil;
+import codesquad.web.dto.AnswerSaveRequestDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/questions/{index}/answers")
+public class ApiAnswerController {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    @PostMapping("")
+    public Answer create(@PathVariable Long index, @RequestBody AnswerSaveRequestDto answerSaveRequestDto, HttpSession httpSession) {
+        if(!HttpSessionUtil.isLoginUser(httpSession)) {
+            return null;
+        }
+
+        User sessionedUser = HttpSessionUtil.getUserFrom(httpSession);
+        Question savedQuestion = questionRepository.findById(index).orElseThrow(() -> new NoSuchElementException("게시글이 존재하지 않습니다."));
+        Answer answer = new Answer(sessionedUser, savedQuestion, answerSaveRequestDto.getContents());
+        savedQuestion.addCountOfAnswer();
+
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -1,5 +1,6 @@
 package codesquad.web;
 
+import codesquad.domain.Result;
 import codesquad.domain.answer.Answer;
 import codesquad.domain.answer.AnswerRepository;
 import codesquad.domain.question.Question;
@@ -38,16 +39,16 @@ public class ApiAnswerController {
     }
 
     @DeleteMapping("/{id}")
-    public Answer delete(@PathVariable Long index, @PathVariable Long id, HttpSession httpSession) {
+    public Result<Answer> delete(@PathVariable Long index, @PathVariable Long id, HttpSession httpSession) {
         if(!HttpSessionUtil.isLoginUser(httpSession)) {
-            throw new IllegalStateException("세션이 만료되었습니다. 다시 로그인 해주세요.");
+            return Result.fail("세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
 
         Answer savedAnswer = answerRepository.findQuestionFetchJoinById(id).orElseThrow(() -> new NoSuchElementException("답변이 존재하지 않습니다."));
         User sessionedUser = HttpSessionUtil.getUserFrom(httpSession);
 
         if (!savedAnswer.isSameWriter(sessionedUser)) {
-            throw new IllegalStateException("다른 사람의 게시글을 삭제할 수 없습니다.");
+            return Result.fail("다른 사람의 게시글을 삭제할 수 없습니다.");
         }
 
         savedAnswer.delete();
@@ -59,6 +60,6 @@ public class ApiAnswerController {
 
         questionRepository.save(savedQuestion);
 
-        return savedAnswer;
+        return Result.ok(savedAnswer);
     }
 }

--- a/src/main/java/codesquad/web/QuestionController.java
+++ b/src/main/java/codesquad/web/QuestionController.java
@@ -134,7 +134,7 @@ public class QuestionController {
             }
 
             if (!savedQuestion.canDelete()) {
-                throw new IllegalStateException("질문에 다른 사용자의 답변이 존재하여 질문을 삭제할 수 없습니다.");
+                throw new IllegalStateException("질문을 삭제할 수 없습니다.");
             }
 
             savedQuestion.delete();

--- a/src/main/java/codesquad/web/dto/AnswerSaveRequestDto.java
+++ b/src/main/java/codesquad/web/dto/AnswerSaveRequestDto.java
@@ -1,0 +1,10 @@
+package codesquad.web.dto;
+
+public class AnswerSaveRequestDto {
+
+    private String contents;
+
+    public String getContents() {
+        return contents;
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO USER (id, user_id, password, name, email) VALUES (1, 'javajigi', 'test', '자바지기', 'javajigi@slipp.net');
-INSERT INTO USER (id, user_id, password, name, email) VALUES (2, 'sanjigi', 'test', '산지기', 'sanjigi@slipp.net');
+INSERT INTO USER (id, created_date, user_id, password, name, email) VALUES (1, '2022-04-18 16:20:29.311', 'javajigi', 'test', '자바지기', 'javajigi@slipp.net');
+INSERT INTO USER (id, created_date, user_id, password, name, email) VALUES (2, '2022-04-18 16:20:29.311', 'sanjigi', 'test', '산지기', 'sanjigi@slipp.net');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,4 @@
 INSERT INTO USER (id, created_date, user_id, password, name, email) VALUES (1, '2022-04-18 16:20:29.311', 'javajigi', 'test', '자바지기', 'javajigi@slipp.net');
 INSERT INTO USER (id, created_date, user_id, password, name, email) VALUES (2, '2022-04-18 16:20:29.311', 'sanjigi', 'test', '산지기', 'sanjigi@slipp.net');
+
+INSERT INTO QUESTION(index, created_date, contents, count_of_answer, deleted, title, writer_id) VALUES(1, '2022-04-19 16:20:29.311', '자동차 경주 게임을 수행하세요.', 0, false, '오늘의 미션은?', 1);

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -97,9 +97,10 @@ function deleteAnswerHandler(evt) {
   })
 }
 
-function deleteAnswer({id}) {
-  console.log(id);
-  const target = $(`.article-comment[data-id='${id}']`);
+function deleteAnswer({data}) {
+  console.log(data);
+  console.log(data.id);
+  const target = $(`.article-comment[data-id='${data.id}']`);
   console.log(target);
   console.log(target.parentNode);
   target.parentNode.removeChild(target);

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -18,8 +18,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 function initEvents() {
   const answerBtn = $(".submit-write .btn");
-  if(answerBtn === null) return;
+  const deleteBtn = $(".delete-answer-button");
   answerBtn.addEventListener("click", registerAnswerHandler);
+  deleteBtn.addEventListener("click", deleteAnswerHandler);
 }
 
 function fetchManager({ url, method, body, headers, callback}) {
@@ -49,7 +50,7 @@ function registerAnswerHandler(evt) {
 
 function appendAnswer({id, contents, question, writer, createdDate}) {
   const html = `
-    <article class="article">
+    <article class="article-comment" data-id=${id}>
        <div class="article-header">
             <div class="article-header-thumb">
                 <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
@@ -78,4 +79,24 @@ function appendAnswer({id, contents, question, writer, createdDate}) {
     </article>`
 
   $('.qna-comment-slipp-articles').insertAdjacentHTML('afterbegin', html);
+}
+
+function deleteAnswerHandler(evt) {
+  if(evt.target.className !== "answer-delete-button") return;
+  evt.preventDefault();
+
+  const url = $(".delete-answer-form").action;
+
+  fetchManager({
+    url: url,
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json'},
+    callback: deleteAnswer
+  })
+}
+
+function deleteAnswer({id}) {
+  const target = $(`.article-comment[data-id='${id}']`);
+  target.parentNode.removeChild(target);
+
 }

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -7,3 +7,75 @@ String.prototype.format = function() {
         ;
   });
 };
+
+function $(selector) {
+  return document.querySelector(selector);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  initEvents();
+})
+
+function initEvents() {
+  const answerBtn = $(".submit-write .btn");
+  if(answerBtn === null) return;
+  answerBtn.addEventListener("click", registerAnswerHandler);
+}
+
+function fetchManager({ url, method, body, headers, callback}) {
+  fetch(url, {method,body,headers,credentials: "same-origin"})
+      .then((response) => {
+        return response.json()
+      }).then((result) => {
+        callback(result)
+      })
+}
+
+function registerAnswerHandler(evt) {
+  evt.preventDefault();
+  const contents = $(".submit-write textarea").value;
+  $(".form-control").value = "";
+
+  const url = $(".submit-write").action;
+
+  fetchManager({
+    url: url,
+    method: 'POST',
+    headers: { 'content-type': 'application/json'},
+    body: JSON.stringify({contents}),
+    callback: appendAnswer
+  })
+}
+
+function appendAnswer({id, contents, question, writer, createdDate}) {
+  const html = `
+    <article class="article">
+       <div class="article-header">
+            <div class="article-header-thumb">
+                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
+            </div>
+            <div class="article-header-text">
+                <a href="#" class="article-author-name">${writer.name}</a>
+                <div class="article-header-time">${createdDate}</div>
+            </div>
+        </div>
+        <div class="article-doc comment-doc">
+            ${contents}
+        </div>
+        <div class="article-util">
+        <ul class="article-util-list">
+            <li>
+                <a class="link-modify-article" href="/questions/${question.index}/answers/${id}">수정</a>
+            </li>
+            <li>
+                <form class="delete-answer-form" action="/questions/${question.index}/answers/${id}" method="POST">
+                <input type="hidden" name="_method" value="DELETE">
+                 <button type="submit" class="delete-answer-button">삭제</button>
+                </form>
+            </li>
+        </ul>
+        </div>
+    </article>`
+
+  $('.qna-comment-slipp-articles').insertAdjacentHTML('afterbegin', html);
+}

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -18,9 +18,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
 function initEvents() {
   const answerBtn = $(".submit-write .btn");
-  const deleteBtn = $(".delete-answer-button");
+
+  console.log(answerBtn);
   answerBtn.addEventListener("click", registerAnswerHandler);
-  deleteBtn.addEventListener("click", deleteAnswerHandler);
+  $('.qna-comment-slipp-articles').addEventListener('click',deleteAnswerHandler);
 }
 
 function fetchManager({ url, method, body, headers, callback}) {
@@ -35,8 +36,7 @@ function fetchManager({ url, method, body, headers, callback}) {
 function registerAnswerHandler(evt) {
   evt.preventDefault();
   const contents = $(".submit-write textarea").value;
-  $(".form-control").value = "";
-
+  $(".submit-write textarea").value = "";
   const url = $(".submit-write").action;
 
   fetchManager({
@@ -69,7 +69,7 @@ function appendAnswer({id, contents, question, writer, createdDate}) {
                 <a class="link-modify-article" href="/questions/${question.index}/answers/${id}">수정</a>
             </li>
             <li>
-                <form class="delete-answer-form" action="/questions/${question.index}/answers/${id}" method="POST">
+                <form class="delete-answer-form" action="/api/questions/${question.index}/answers/${id}" method="POST">
                 <input type="hidden" name="_method" value="DELETE">
                  <button type="submit" class="delete-answer-button">삭제</button>
                 </form>
@@ -82,10 +82,12 @@ function appendAnswer({id, contents, question, writer, createdDate}) {
 }
 
 function deleteAnswerHandler(evt) {
-  if(evt.target.className !== "answer-delete-button") return;
+  console.log(evt.target.className);
+  if(evt.target.className !== "delete-answer-button") return;
   evt.preventDefault();
 
   const url = $(".delete-answer-form").action;
+  console.log(url);
 
   fetchManager({
     url: url,
@@ -96,7 +98,9 @@ function deleteAnswerHandler(evt) {
 }
 
 function deleteAnswer({id}) {
+  console.log(id);
   const target = $(`.article-comment[data-id='${id}']`);
+  console.log(target);
+  console.log(target.parentNode);
   target.parentNode.removeChild(target);
-
 }

--- a/src/main/resources/templates/failed.html
+++ b/src/main/resources/templates/failed.html
@@ -1,3 +1,0 @@
-{{>layout/header}}
-<h2>수정할 수 없습니다.</h2>
-{{>layout/footer}}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -14,7 +14,7 @@
                           </strong>
                           <div class="auth-info">
                               <i class="icon-add-comment"></i>
-                              <span class="time">2016-01-15 18:47</span>
+                              <span class="time">{{createdDate}}</span>
                               <a href="./user/profile.html" class="author">{{writer.name}}</a>
                           </div>
                           <div class="reply" title="댓글">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,7 +5,7 @@
       <div class="panel panel-default qna-list">
           <ul class="list">
               {{#questions}}
-              {{^isDeleted}}
+              {{^deleted}}
               <li>
                   <div class="wrap">
                       <div class="main">
@@ -24,7 +24,7 @@
                       </div>
                   </div>
               </li>
-              {{/isDeleted}}
+              {{/deleted}}
               {{/questions}}
           </ul>
           <div class="row">

--- a/src/main/resources/templates/layout/footer.html
+++ b/src/main/resources/templates/layout/footer.html
@@ -1,6 +1,6 @@
 <!-- script references -->
-<script src="js/jquery-2.2.0.min.js"></script>
-<script src="js/bootstrap.min.js"></script>
-<script src="js/scripts.js"></script>
+<script src="/js/jquery-2.2.0.min.js"></script>
+<script src="/js/bootstrap.min.js"></script>
+<script src="/js/scripts.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -16,7 +16,7 @@
                       <div class="article-header-text">
                           <a href="/users/92/kimmunsu" class="article-author-name">{{writer.name}}</a>
                           <a href="/questions/413" class="article-header-time" title="퍼머링크">
-                              2015-12-30 01:47
+                              {{createdDate}}
                               <i class="icon-link"></i>
                           </a>
                       </div>
@@ -63,7 +63,7 @@
                                   <div class="article-header-text">
                                       <a href="/users/1/자바지기" class="article-author-name">{{writer.userId}}</a>
                                       <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                          2016-01-12 14:06
+                                          {{createdDate}}
                                       </a>
                                   </div>
                               </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -76,7 +76,7 @@
                                           <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
                                       </li>
                                       <li>
-                                          <form class="delete-answer-form" action="/questions/{{{index}}}/answers/{{{id}}}" method="POST">
+                                          <form class="delete-answer-form" action="/api/questions/{{{index}}}/answers/{{{id}}}" method="POST">
                                               <input type="hidden" name="_method" value="DELETE">
                                               <button type="submit" class="delete-answer-button">삭제</button>
                                           </form>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -76,7 +76,7 @@
                                           <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
                                       </li>
                                       <li>
-가                                          <form class="delete-answer-form" action="/questions/{{{index}}}/answers/{{{id}}}" method="POST">
+                                          <form class="delete-answer-form" action="/questions/{{{index}}}/answers/{{{id}}}" method="POST">
                                               <input type="hidden" name="_method" value="DELETE">
                                               <button type="submit" class="delete-answer-button">삭제</button>
                                           </form>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -54,7 +54,7 @@
                       <p class="qna-comment-count"><strong>{{countOfAnswer}}</strong>개의 의견</p>
                       <div class="qna-comment-slipp-articles">
                           {{#answers}}
-                          {{^isDeleted}}
+                          {{^deleted}}
                           <article class="article" id="answer-1405">
                               <div class="article-header">
                                   <div class="article-header-thumb">
@@ -84,9 +84,9 @@
                                   </ul>
                               </div>
                           </article>
-                          {{/isDeleted}}
+                          {{/deleted}}
                           {{/answers}}
-                          <form class="submit-write" method="post" action="/questions/{{index}}/answers">
+                          <form class="submit-write" method="post" action="/api/questions/{{index}}/answers">
                               <div class="form-group" style="padding:14px;">
                                   <textarea class="form-control" placeholder="Update your status" name="contents"></textarea>
                               </div>
@@ -101,35 +101,5 @@
         </div>
     </div>
 </div>
-
-<script type="text/template" id="answerTemplate">
-	<article class="article">
-		<div class="article-header">
-			<div class="article-header-thumb">
-				<img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-			</div>
-			<div class="article-header-text">
-				<a href="#" class="article-author-name">{0}</a>
-				<div class="article-header-time">{1}</div>
-			</div>
-		</div>
-		<div class="article-doc comment-doc">
-			{2}
-		</div>
-		<div class="article-util">
-		<ul class="article-util-list">
-			<li>
-				<a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
-			</li>
-			<li>
-				<form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-					<input type="hidden" name="_method" value="DELETE">
-                     <button type="submit" class="delete-answer-button">삭제</button>
-				</form>
-			</li>
-		</ul>
-		</div>
-	</article>
-</script>
 
 {{>layout/footer}}

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -55,7 +55,7 @@
                       <div class="qna-comment-slipp-articles">
                           {{#answers}}
                           {{^deleted}}
-                          <article class="article" id="answer-1405">
+                          <article class="article-comment" data-id="{{id}}">
                               <div class="article-header">
                                   <div class="article-header-thumb">
                                       <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">


### PR DESCRIPTION
## 현재의 요구사항 정리

* 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태로 변경한다.
* 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태를 변경한다.
* 로그인한 사용자와 질문한 사람이 같은 경우 삭제 가능하다. 
* 답변이 없는 경우 삭제가 가능하다.
* 질문 데이터는 질문자와 답변 글의 모든 답변자가 같은 경우 삭제 가능하다.
* 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.



현재의 요구사항을 고려했을 때 질문데이터와 답변데이터는 완전한 삭제가 아닌 삭제 상태를 갖는다. 그렇기 때문에 데이터는 삭제라는 '상태'를 가지고, view에서 보여질 때는 삭제 상태인지 아닌지를 판단 후 보여져야 한다. 데이터의 완전한 삭제를 고려하지 않으니 영속성 전이 속성 또한 아직은 필요하지 않을 것 같다.

질문 데이터가 삭제될 수 있는 선택지에는 

1. 댓글이 처음부터 달리지 않아 질문데이터가 보유한 댓글 갯수가 0인 경우
2. 질문데이터가 보유한 댓글 데이터의 모든 삭제 상태가 true인 경우
3. 질문데이터에 작성한 모든 댓글이 해당 질문을 작성한 사용자의 댓글인 경우이다.

------

## 기존 구현에서 수정되어야 할 부분

댓글을 생성 후 해당 사용자인지 아닌지를 검사 후 해당 사용자일 경우 댓글 삭제 버튼이 보이도록 구현을 생각했음. 생각을 다시해보니 댓글을 작성할 수 있는 권한은 해당 사용자에게만 있는데 작성 후 보여지는 페이지에서 작성자인지 아닌지를 검사할 필요가 없다고 생각함. -> (추후 수정 예정)



e.preventDefault() : 서버로 데이터 전송 기능을 막음