### PR TITLE
[6주차 미션] 구현 완료했습니다. 리뷰 부탁드립니다.

### DIFF
--- a/src/main/java/codesquad/controller/AnswerController.java
+++ b/src/main/java/codesquad/controller/AnswerController.java
@@ -8,7 +8,6 @@ import codesquad.repository.QuestionRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -67,9 +66,6 @@ public class AnswerController {
     }
 
     private Object getSessionValue(HttpSession session) {
-
         return session.getAttribute("sessionedUser");
     }
-
-
 }

--- a/src/main/java/codesquad/controller/ApiAnswerController.java
+++ b/src/main/java/codesquad/controller/ApiAnswerController.java
@@ -1,0 +1,54 @@
+package codesquad.controller;
+
+import codesquad.domain.*;
+import codesquad.repository.AnswerRepository;
+import codesquad.repository.QuestionRepository;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+@RestController
+public class ApiAnswerController {
+
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+
+    public ApiAnswerController(QuestionRepository questionRepository, AnswerRepository answerRepository) {
+        this.questionRepository = questionRepository;
+        this.answerRepository = answerRepository;
+    }
+
+    @PostMapping("/api/questions/{question-id}/answers")
+    public Answer create(@PathVariable("question-id") Long questionId, @RequestBody AnswerDto answerDto, HttpSession session) {
+        if (!HttpSessionUtils.isLoginUser(session)) {
+            return null;
+        }
+
+        User loginUser = HttpSessionUtils.getUserFromSession(session);
+        Question question = questionRepository.findById(questionId)
+                                              .orElseThrow(NoSuchElementException::new);
+        Answer answer = new Answer(loginUser, question, answerDto.getContents(), LocalDateTime.now());
+
+        return answerRepository.save(answer);
+    }
+
+    @DeleteMapping("/api/questions/{question-id}/answers/{answer-id}")
+    public Result<Answer> remove(@PathVariable("question-id") Long questionId, @PathVariable("answer-id") Long answerId, HttpSession session) {
+        if (!HttpSessionUtils.isLoginUser(session)) {
+            return Result.fail("로그인이 필요한 서비스 입니다.");
+        }
+        User loginUser = HttpSessionUtils.getUserFromSession(session);
+        Answer answer = answerRepository.findById(answerId)
+                                        .orElseThrow(NoSuchElementException::new);
+
+        if (!answer.isSameWriter(loginUser)) {
+            return Result.fail("다른 사용자의 답변을 삭제할 수 없습니다.");
+        }
+        answer.setDeletedFlag(true);
+        answerRepository.save(answer);
+
+        return Result.ok(answer);
+    }
+}

--- a/src/main/java/codesquad/controller/QuestionController.java
+++ b/src/main/java/codesquad/controller/QuestionController.java
@@ -127,6 +127,7 @@ public class QuestionController {
                     if (question.getAnswers()
                                 .size() == 0) {
                         question.setDeleteFlag(true);
+                        questionRepository.save(question);
                     } else {
                         boolean flag = true;
                         for (Answer answer : question.getAnswers()) {
@@ -142,6 +143,7 @@ public class QuestionController {
                             question.getAnswers()
                                     .clear();
                             question.setDeleteFlag(true);
+                            questionRepository.save(question);
                         }
                     }
                 }

--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -19,6 +19,17 @@ public class Answer {
     private String comment;
 
     private LocalDateTime localDateTime;
+    private boolean deletedFlag;
+
+    public Answer() {
+    }
+
+    public Answer(User loginUser, Question question, String comment, LocalDateTime localDateTime) {
+        this.writer = loginUser.getName();
+        this.question = question;
+        this.comment = comment;
+        this.localDateTime = localDateTime;
+    }
 
     public Long getId() {
         return id;
@@ -53,6 +64,14 @@ public class Answer {
         this.localDateTime = localDateTime;
     }
 
+    public boolean isDeletedFlag() {
+        return deletedFlag;
+    }
+
+    public void setDeletedFlag(boolean deletedFlag) {
+        this.deletedFlag = deletedFlag;
+    }
+
     public void writeAnswer(String comment, String writer, LocalDateTime localDateTime) {
         this.comment = comment;
         this.localDateTime = localDateTime;
@@ -62,5 +81,9 @@ public class Answer {
     public void addQuestion(Question question) {
         question.getAnswers().add(this);
         this.question = question;
+    }
+
+    public boolean isSameWriter(User user) {
+        return this.writer.equals(user.getName());
     }
 }

--- a/src/main/java/codesquad/domain/AnswerDto.java
+++ b/src/main/java/codesquad/domain/AnswerDto.java
@@ -1,0 +1,9 @@
+package codesquad.domain;
+
+public class AnswerDto {
+    private String contents;
+
+    public String getContents() {
+        return contents;
+    }
+}

--- a/src/main/java/codesquad/domain/HttpSessionUtils.java
+++ b/src/main/java/codesquad/domain/HttpSessionUtils.java
@@ -1,0 +1,14 @@
+package codesquad.domain;
+
+import javax.servlet.http.HttpSession;
+
+public class HttpSessionUtils {
+
+    public static boolean isLoginUser(HttpSession session) {
+        return session.getAttribute("sessionedUser") != null;
+    }
+
+    public static User getUserFromSession(HttpSession session) {
+        return (User) session.getAttribute("sessionedUser");
+    }
+}

--- a/src/main/java/codesquad/domain/Question.java
+++ b/src/main/java/codesquad/domain/Question.java
@@ -1,5 +1,7 @@
 package codesquad.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,6 +19,8 @@ public class Question {
     private String title;
     private String contents;
     private LocalDateTime time;
+
+    @JsonIgnore
     @OneToMany(mappedBy = "question")
     private final List<Answer> answers = new ArrayList<>();
     private Boolean deleteFlag;
@@ -54,10 +58,6 @@ public class Question {
 
     public void setContents(String contents) {
         this.contents = contents;
-    }
-
-    public void createWrittenTime(LocalDateTime writtenTime) {
-        this.time = writtenTime;
     }
 
     public Long getId() {

--- a/src/main/java/codesquad/domain/Result.java
+++ b/src/main/java/codesquad/domain/Result.java
@@ -1,0 +1,28 @@
+package codesquad.domain;
+
+public class Result<T> {
+    private T t;
+    private String message;
+
+    public Result(T t, String message) {
+        System.out.println("t 값 = " + t.toString());
+        this.t = t;
+        this.message = message;
+    }
+
+    public static <T> Result<T> ok(T t) {
+        return new Result<>(t, "ok");
+    }
+
+    public static <T> Result<T> fail(String message) {
+        return new Result<>(null, message);
+    }
+
+    public T getT() {
+        return t;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 spring.jpa.hibernate.ddl-auto=create-drop
 server.servlet.session.tracking-modes=cookie
+
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -7,3 +7,129 @@ String.prototype.format = function () {
             ;
     });
 };
+
+function $(selector) {
+    return document.querySelector(selector);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    console.log("호출 되는가?");
+    initEvents();
+})
+
+function initEvents() {
+    const answerBtn = $(".submit-write .btn");
+    console.log("answerBtn =" + answerBtn);
+    answerBtn.addEventListener("click", registerAnswerHandler);
+    $('.qna-comment-slipp-articles').addEventListener('click', deleteAnswerHandler);
+}
+
+function fetchManager({url, method, body, headers, callback}) {
+    fetch(url, {
+        //fetch("http://xxx.com/dd", {
+        method,
+        body,
+        headers,
+        credentials: "same-origin"
+    }).then((response) => {
+        return response.json().then(result => {
+            return {
+                'result': result,
+                'status': response.status
+            }
+        })
+    }).then(({result, status}) => {
+        if (status >= 400) {
+            console.log('error 가 발생했네요 ', result.error);
+        } else {
+            console.log(result);
+            callback(result)
+        }
+    }).catch(err => {
+        console.log("oops..", err)
+    })
+}
+
+function registerAnswerHandler(evt) {
+    evt.preventDefault();
+    const contents = $(".submit-write textarea").value;
+    document.querySelectorAll(".form-control")[1].value = "";
+    // $(".submit-write textarea").value = "";
+    const url = $(".submit-write").action;
+
+    console.log("registerAnswerHandler fetchManager 호출되기 전");
+    fetchManager({
+        url: url,
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({contents}),
+        callback: appendAnswer
+    })
+    console.log("registerAnswerHandler fetchManager 호출됨");
+}
+
+function appendAnswer({id, question, writer, comment, localDateTime}) {
+    console.log("appendAnswer() 호출 id=" + id);
+    console.log("writer =" + writer);
+    console.log("question.id =" + question.id);
+
+    const html = `
+    <article class="article-comment" data-id=${id}>
+       <div class="article-header">
+            <div class="article-header-thumb">
+                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
+            </div>
+            <div class="article-header-text">
+                <a href="#" class="article-author-name">${writer}</a>
+                <div class="article-header-time">${localDateTime}</div>
+            </div>
+        </div>
+        <div class="article-doc comment-doc">
+            ${comment}
+        </div>
+        <div class="article-util">
+        <ul class="article-util-list">
+            <li>
+               <a class="link-modify-article" href="/api/questions/${question.id}/answers/${id}">수정</a>
+            </li>
+            <li>
+                <form class="delete-answer-form" action="/api/questions/${question.id}/answers/${id}" method="POST">
+                <input type="hidden" name="_method" value="DELETE">
+                 <button type="submit" class="delete-answer-button">삭제</button>
+                </form>
+            </li>
+        </ul>
+        </div>
+    </article>`
+
+    $('.qna-comment-slipp-articles').insertAdjacentHTML('afterbegin', html);
+}
+
+function deleteAnswerHandler(evt) {
+    console.log(evt.target.className);
+    console.log("evt.target =" + evt.target);
+
+    if (evt.target.className !== "delete-answer-button") return;
+    evt.preventDefault();
+
+    const url = $(".delete-answer-form").action;
+    const id = url.replace(/.+\/(\d+)$/, "$1");
+
+    console.log("url =" + url);
+    console.log(("id =" + id));
+    fetchManager({
+        url: url,
+        method: 'DELETE',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({id}),
+        callback: deleteAnswer
+    })
+}
+
+function deleteAnswer({t}) {
+    console.log("answerid =" + t);
+    const selector = $(`.article-comment[data-id='${t.id}']`);
+    console.log("target 값 =" + selector);
+    console.log("target,parentNode =" + selector.parentNode)
+    selector.parentNode.removeChild(selector);
+}

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -5,8 +5,7 @@
 </head>
 <body>
 {{> include/content}}
-
-{{#question}
+{{#question}}
 <div class="container" id="main">
     <div class="col-md-12 col-sm-12 col-lg-12">
         <div class="panel panel-default">
@@ -56,7 +55,8 @@
                         <p class="qna-comment-count"><strong>{{count}}</strong>개의 의견</p>
                         <div class="qna-comment-slipp-articles">
                             {{#question.answers}}
-                            <article class="article" id="answer-1405">
+                            {{^deletedFlag}}
+                            <article class="article-comment" data-id="{{id}}">
                                 <div class="article-header">
                                     <div class="article-header-thumb">
                                         <img alt=""
@@ -80,23 +80,25 @@
                                                href="/questions/413/answers/1405/form">수정</a>
                                         </li>
                                         <li>
-                                            <form action="/questions/{{question.id}}/answers/{{id}}" class="delete-answer-form"
+                                            <form action="/api/questions/{{question.id}}/answers/{{id}}"
+                                                  class="delete-answer-form"
                                                   method="POST">
                                                 <input name="_method" type="hidden" value="DELETE">
                                                 <button class="delete-answer-button" type="submit">삭제</button>
                                             </form>
                                     </ul>
                                 </div>
-                                {{/question.answers}}
                             </article>
-                            <form class="submit-write" action="/questions/{{id}}/answers", method="POST">
+                            {{/deletedFlag}}
+                            {{/question.answers}}
+                            <form , action="/api/questions/{{id}}/answers" class="submit-write" method="POST">
                                 <div class="form-group" style="padding:14px;">
-                                    <textarea class="form-control" placeholder="Update your status" name="comment"></textarea>
+                                    <textarea class="form-control" name="comment"
+                                              placeholder="Update your status"></textarea>
                                 </div>
-                                <button class="btn btn-success clearfix pull-right" type="submit" >답변하기</button>
+                                <button class="btn btn-success clearfix pull-right" type="submit">답변하기</button>
                                 <div class="clearfix"/>
                             </form>
-
                         </div>
                     </div>
                 </div>
@@ -105,37 +107,6 @@
         </div>
     </div>
 </div>
-
-
-<script id="answerTemplate" type="text/template">
-    <article class="article">
-        <div class="article-header">
-            <div class="article-header-thumb">
-                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-            </div>
-            <div class="article-header-text">
-                <a href="#" class="article-author-name">{0}</a>
-                <div class="article-header-time">{1}</div>
-            </div>
-        </div>
-        <div class="article-doc comment-doc">
-            {2}
-        </div>
-        <div class="article-util">
-            <ul class="article-util-list">
-                <li>
-                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
-                </li>
-                <li>
-                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-                        <input type="hidden" name="_method" value="DELETE">
-                        <button type="submit" class="delete-answer-button">삭제</button>
-                    </form>
-                </li>
-            </ul>
-        </div>
-    </article>
-</script>
 
 <!-- script references -->
 {{> include/footer}}


### PR DESCRIPTION
### AJAX(Asynchronous Javascript And XML)

브라우저가 가지고 있는 `XMLHttpRequest` 객체를 이용해서 전체 페이지를 새로 고치지 않고도 페이지의 일부만을 위한 데이터를 로드하는 기법이다. 즉 자바스크립트를 이용해서 비동기적으로 클라이언트-서버간에 XML 데이터를 주고 받는 기술이다.

### AJAX를 사용하는 이유?

AJAX를 이용하면 HTML **페이지 전체를 갱신하지 않고 필요한 데이터 일부분만 받아 갱신함으로써 자원과 시간을 아낄 수 있다**. 이로 인해 다음과 같은 이점을 가질 수 있게된다.

- 속도 향상
- 서버의 처리가 완료될때까지 기다리지 않아도 된다
- 등등

여러가지 AJAX 구현 방식 중에 fetch API를 사용하였는데, 이벤트 기반인 `XMLHttpRequest`와는 달리 fetch API는 `Promise` 기반으로 되어있어 **비동기 처리 방식**에 적합하다고 한다.

즉 결론적으로 AJAX를 잘 사용하면 불필요한 요청을 줄일 수 있게된다.



### `Question` 클래스의 `OneToMany`와 `Answer` 클래스의 `ManyToOne`간 무한 순환참조 에러

- 원인

  JPA 연관관계에서 양방향 매핑을 선언한 경우 발생한다.

  Jackson 라이브러리의 ObjectMapeer 객체에 의해 컨트롤러 단에서 JSON 타입을 변환하는 도중에 변환되는 엔티티의 필드가 다른 엔티티를 참조하고 그 엔티티 클래스의 필드가 또 다른 엔티티를 참조하는 과정이 무한으로 반복되면서 `StackOverflow` 에러가 발생한다.

- 해결법

  1. 참조가 되는 앞 부분에 `@JsonManagedReference` 어노테이션을 붙여 정상적으로 직렬화를 수행하도록 한다.
  2. 참조가 되는 뒷 부분에 `@JsonBackReference`어노테이션을 붙여 직렬화를 수행하지 않도록 한다.

  위와 같이 직렬화되는 방향을 한 방향으로 설정함으로써 해결할 수 있다.

### + 추가 오류) 직렬화를 막아 놓아서 값 참조가 불가능한 경우

`Answer` 클래스의 `Question`필드의 `id`를 `script.js`에서 호출하여 사용하려고 하였으나 위에서 `@JsonBackReference` 어노테이션으로 직렬화를 막아놓았더니 값을 참조하지 못하여 에러가 발생하였다.

무한 순환참조를 막아야하고, 값 참조도 가능하게 구현하기 위해서 기존 해결 방법을 지우고, `Question` 클래스에 `@JsonIgnore` 어노테이션을 추가하여 직렬화를 막아놓고, `Answer` 클래스는 열어 놓음으로써 문제를 해결할 수 있었다.


### 마무리하며

여러가지 문제점들을 남겨놓은 채로 PR을 날립니다..ㅠㅠ

1. 중첩 if문 리팩토링
2. `HttpSessionUtils` 이용하여 코드 리팩토링
3. 새로고침하면 추가된 답글의 순서가 바뀌는 문제
4. 삭제 후 새로고침을 해야 화면이 갱신되는 문제

처음 접하는 내용들을 당장 구현하는것에 급급하다 보니 신경쓰지 못한 부분들이 많아 아쉬움이 많이 남는 것 같습니다.. 앞선 리뷰들도 아직 반영하지 못한 부분들이 있는데 빠르게 따라가보도록 하겠습니다!